### PR TITLE
greedy algorithm updates

### DIFF
--- a/vins_estimator/src/feature_selector.cpp
+++ b/vins_estimator/src/feature_selector.cpp
@@ -586,6 +586,9 @@ void FeatureSelector::keepInformativeFeatures(image_t& image, int kappa,
 
       // add feature that returns the most information to the subset
       subset[lMax] = image.at(lMax);
+
+      // mark as used
+      blacklist.push_back(lMax);
     }
   }
 

--- a/vins_estimator/src/feature_selector.h
+++ b/vins_estimator/src/feature_selector.h
@@ -224,7 +224,7 @@ private:
    */
   void keepInformativeFeatures(image_t& image, int kappa,
         const omega_horizon_t& Omega, const delta_ls& Delta_ells,
-        const delta_ls& Delta_used_ells, Eigen::VectorXd& probFeatureTracked);
+        const delta_ls& Delta_used_ells, std::map<int, int>& probFeatureTracked);
 
   /**
    * @brief      Make a new subset of type image_t
@@ -252,7 +252,7 @@ private:
   double logDet(image_t& currentSubset,
                 const omega_horizon_t& Omega,
                 const delta_ls& Delta_ells,
-                Eigen::VectorXd& probFeatureTracked);
+                std::map<int, int>& probFeatureTracked);
 
   /**
    * @brief      Calculate and sort upper bounds of logDet cost function of
@@ -270,7 +270,7 @@ private:
 
   std::map<double, int, std::greater<double>> sortedlogDetUB(const omega_horizon_t& Omega,
                         const delta_ls& Delta_ells, image_t& subset,
-                        const image_t& image, Eigen::VectorXd& probFeatureTracked);
+                        const image_t& image, std::map<int, int>& probFeatureTracked);
 
   // In case we have extra time for another cost function
   // (though we know minEig to be slower than logDet)

--- a/vins_estimator/src/feature_selector.h
+++ b/vins_estimator/src/feature_selector.h
@@ -71,6 +71,13 @@ private:
 
   Estimator& estimator_; ///< Reference to vins estimator object
 
+  /**
+   * @brief This is the largest feature_id from the previous frame.
+   *        In other words, every feature_id that is larger than
+   *        this id is considered a new feature to be selected.
+   */
+  int lastFeatureId_ = 0;
+
   // extrinsic parameters: camera frame w.r.t imu frame
   Eigen::Quaterniond q_IC_;
   Eigen::Vector3d t_IC_;
@@ -124,6 +131,15 @@ private:
   // nanoflann kdtree for guessing depth from existing landmarks
   typedef nanoflann::KDTreeSingleIndexAdaptor<nanoflann::L2_Simple_Adaptor<double, PointCloud>, PointCloud, 2/*dim*/> my_kd_tree_t;
   std::unique_ptr<my_kd_tree_t> kdtree_;
+
+  /**
+   * @brief      Split features on the provided key
+   *
+   * @param[in]  k          feature_id to split on (k will not be in image_new)
+   * @param      image      Feature set to split
+   * @param      image_new  Any features with id after k
+   */
+  void splitOnFeatureId(int k, image_t& image, image_t& image_new);
 
   /**
    * @brief      Generate a future state horizon from k+1 to k+H

--- a/vins_estimator/src/feature_selector.h
+++ b/vins_estimator/src/feature_selector.h
@@ -112,7 +112,7 @@ private:
     inline double kdtree_get_pt(const size_t idx, const size_t dim) const
     {
         if (dim == 0) return pts[idx].first;
-        else if (dim == 1) return pts[idx].second;
+        else /*if (dim == 1)*/ return pts[idx].second;
     }
 
     // Optional bounding-box computation: return false to default to a standard bbox computation loop.
@@ -222,11 +222,9 @@ private:
    *
    * @return     void               Swaps out image set of features with subset
    */
-  void keepInformativeFeatures(image_t& image, int& kappa,
-          const omega_horizon_t& Omega_kkH,
-          const delta_ls& Delta_ells,
-          const delta_ls& Delta_used_ells,
-          Eigen::VectorXd& probFeatureTracked);
+  void keepInformativeFeatures(image_t& image, int kappa,
+        const omega_horizon_t& Omega, const delta_ls& Delta_ells,
+        const delta_ls& Delta_used_ells, Eigen::VectorXd& probFeatureTracked);
 
   /**
    * @brief      Make a new subset of type image_t
@@ -270,15 +268,12 @@ private:
    *                                  and feature IDs
    */
 
-  std::map<double,int,std::greater<double>> sortedlogDetUB(const omega_horizon_t& Omega,
+  std::map<double, int, std::greater<double>> sortedlogDetUB(const omega_horizon_t& Omega,
                         const delta_ls& Delta_ells, image_t& subset,
                         const image_t& image, Eigen::VectorXd& probFeatureTracked);
 
-  // In case we have extra time for another cost function (though we know
-  // to be slower than logDet)
-  double minEig(const omega_horizon_t& Omega,
-                const delta_ls& Delta_ell);
-
-  double minEigUB(const omega_horizon_t& Omega,
-                  const delta_ls& Delta_ell);
+  // In case we have extra time for another cost function
+  // (though we know minEig to be slower than logDet)
+  double minEig(const omega_horizon_t& Omega, const delta_ls& Delta_ell) { return 0; }
+  double minEigUB(const omega_horizon_t& Omega, const delta_ls& Delta_ell) { return 0; }
 };

--- a/vins_estimator/src/utility/state_defs.h
+++ b/vins_estimator/src/utility/state_defs.h
@@ -5,7 +5,7 @@
 
 #include <Eigen/Dense>
 
-#define HORIZON 10 ///< number of frames to look into the future
+#define HORIZON 3 ///< number of frames to look into the future
 
 #define STATE_SIZE 9 ///< size of state as defined in paper III-B1,
                      ///< which comes from the linear IMU model.
@@ -21,7 +21,7 @@ using state_horizon_t = std::array<state_t, HORIZON+1>;
 // information matrices
 using omega_t = Eigen::Matrix<double, STATE_SIZE, STATE_SIZE>;
 using omega_horizon_t = Eigen::Matrix<double, STATE_SIZE*(HORIZON+1), STATE_SIZE*(HORIZON+1)>;
-using delta_ls = std::map<int, Eigen::Matrix<double, STATE_SIZE*(HORIZON+1), STATE_SIZE*(HORIZON+1)>>;
+
 // Ablk -- the non-zero, non-identity matrix in equation (50)
 using ablk_t = Eigen::Matrix<double, STATE_SIZE, STATE_SIZE>;
 
@@ -31,6 +31,8 @@ using ablk_t = Eigen::Matrix<double, STATE_SIZE, STATE_SIZE>;
 // one camera. Also, camera_id == 0.
 using image_t = std::map<int, std::vector<std::pair<int, Eigen::Matrix<double, 7, 1>>>>;
 
+
+using fset_t = std::map<int, omega_horizon_t>;
 
 
 static const Eigen::Vector3d gravity = [] {

--- a/vins_estimator/src/utility/state_defs.h
+++ b/vins_estimator/src/utility/state_defs.h
@@ -32,8 +32,6 @@ using ablk_t = Eigen::Matrix<double, STATE_SIZE, STATE_SIZE>;
 using image_t = std::map<int, std::vector<std::pair<int, Eigen::Matrix<double, 7, 1>>>>;
 
 
-using fset_t = std::map<int, omega_horizon_t>;
-
 
 static const Eigen::Vector3d gravity = [] {
   Eigen::Vector3d tmp;


### PR DESCRIPTION
- determine which features are old / new
- limited the amount of data copying when passing between methods
- added regularization term to `logDet(M)` for numerical stability. The small (`1e-10`) negative eigenvalues of the separate matrices would accumulate into the final additive `M` due to round off error. Thus, `det(M)<0` and the `log` would blow up, returning `nan`.
- silently fail if `lMax==-1` after searching.