### PR TITLE
Use track probabilities from feature tracker

### DIFF
--- a/feature_tracker/CMakeLists.txt
+++ b/feature_tracker/CMakeLists.txt
@@ -132,7 +132,7 @@ catkin_package(
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
 ## Declare a C++ library
-add_library(feature_tracker src/feature_tracker.cpp)
+add_library(feature_tracker src/feature_tracker.cpp src/cvmodified.cpp)
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries

--- a/feature_tracker/include/anticipation/cvmodified.h
+++ b/feature_tracker/include/anticipation/cvmodified.h
@@ -1,0 +1,29 @@
+/**
+ * @file cvmodified.h
+ * @author Parker Lusk <parkerclusk@gmail.com>
+ * @brief Score-returning GFTT
+ */
+
+#pragma once
+
+#include <opencv2/core.hpp>
+
+/**
+ * See https://github.com/plusk01/opencv-gftt-score
+ */
+namespace cvmodified {
+
+  void goodFeaturesToTrack(cv::InputArray image, cv::OutputArray corners,
+        cv::OutputArray scores,
+        int maxCorners, double qualityLevel, double minDistance,
+        cv::InputArray mask=cv::noArray(), int blockSize=3,
+        bool useHarrisDetector=false, double k=0.04);
+
+  void goodFeaturesToTrack(cv::InputArray image, cv::OutputArray corners,
+        cv::OutputArray scores,
+        int maxCorners, double qualityLevel, double minDistance,
+        cv::InputArray mask, int blockSize,
+        int gradientSize,
+        bool useHarrisDetector=false, double k=0.04);
+
+}

--- a/feature_tracker/include/anticipation/feature_tracker.h
+++ b/feature_tracker/include/anticipation/feature_tracker.h
@@ -16,6 +16,9 @@
 
 #include "anticipation/cvmodified.h"
 
+// convenience location identifiers for measurement_t
+enum : int { mID=0, mPT=1, mSCORE=2, mNIP=3, mLIFE=4, mVEL=5 };
+
 namespace anticipation
 {
 
@@ -37,8 +40,8 @@ namespace anticipation
       double reprojErrorF = 1.0;
     };
 
-    // measurement: <id, pt, nip, lifetime, vel>
-    using measurement_t = std::tuple<unsigned int, cv::Point2f,
+    // measurement: <id, pt, score/prob, nip, lifetime, vel>
+    using measurement_t = std::tuple<unsigned int, cv::Point2f, float,
                                   cv::Point2f, unsigned int, cv::Point2f>;
 
     FeatureTracker(const std::string& calib_file, const Parameters& params);
@@ -66,6 +69,7 @@ namespace anticipation
     std::vector<cv::Point2f> features1_;    ///< current features
     std::vector<unsigned int> ids1_;        ///< unique id for each feature
     std::vector<unsigned int> lifetimes1_;  ///< how long each feat. has been tracked
+    std::vector<double> scores1_;           ///< detction score of each feature
 
     // counter for unique id generation
     unsigned int nextId_ = 1;
@@ -102,6 +106,7 @@ namespace anticipation
      */ 
     void detectFeatures(const cv::Mat& grey,
                         std::vector<cv::Point2f>& features,
+                        std::vector<float>& scores,
                         int maxCorners,
                         const cv::Mat& mask = cv::Mat());
 
@@ -135,7 +140,7 @@ namespace anticipation
     bool rejectWithF(std::vector<cv::Point2f>& features0);
 
     /**
-     * @brief      Create measurements (id, nip, lifetime, vel)
+     * @brief      Create measurements (measurement_t)
      *
      * @param[in]  features0  Features from the previous frame
      */

--- a/feature_tracker/include/anticipation/feature_tracker.h
+++ b/feature_tracker/include/anticipation/feature_tracker.h
@@ -6,10 +6,15 @@
 #pragma once
 
 #include <string>
+#include <algorithm>
+#include <iostream>
 
 #include <opencv2/opencv.hpp>
 
 #include <camodocal/camera_models/Camera.h>
+#include <camodocal/camera_models/CameraFactory.h>
+
+#include "anticipation/cvmodified.h"
 
 namespace anticipation
 {
@@ -55,7 +60,6 @@ namespace anticipation
     camodocal::CameraPtr m_camera_; ///< geometric camera model
     Parameters params_; ///< feature tracker parameters
     cv::Ptr<cv::CLAHE> clahe_; ///< contrast-limited adaptive histogram equalization
-    cv::Ptr<cv::GFTTDetector> detector_; ///< feature detector
     cv::Ptr<cv::SparsePyrLKOpticalFlow> flow_; ///< optical flow
 
     // features and related data
@@ -90,13 +94,15 @@ namespace anticipation
     /**
      * @brief      Detect new features in a greyscale image
      *
-     * @param[in]  grey      Greyscale image to find features in
-     * @param      features  The detected images
-     * @param[in]  mask      A mask indicated which areas of the 
-     *                       image to detect features in
+     * @param[in]  grey        Greyscale image to find features in
+     * @param      features    The detected images
+     * @param[in]  maxCorners  Maximum number of corners to detect
+     * @param[in]  mask        A mask indicated which areas of the 
+     *                         image to detect features in
      */ 
     void detectFeatures(const cv::Mat& grey,
                         std::vector<cv::Point2f>& features,
+                        int maxCorners,
                         const cv::Mat& mask = cv::Mat());
 
     /**

--- a/feature_tracker/src/attention_viewer_ros.cpp
+++ b/feature_tracker/src/attention_viewer_ros.cpp
@@ -67,6 +67,7 @@ void AttentionViewerROS::callback(const sensor_msgs::ImageConstPtr& _img,
     int id = static_cast<int>(_features->channels[0].values[i]);
     auto pix = cv::Point2f(_features->channels[1].values[i], _features->channels[2].values[i]);
     auto vel = cv::Point2f(_features->channels[3].values[i], _features->channels[4].values[i]);
+    auto prob = _features->channels[5].values[i];
 
     bool isOld = std::find(oldIds.begin(), oldIds.end(), id) != oldIds.end();
     bool isNew = std::find(newIds.begin(), newIds.end(), id) != newIds.end();
@@ -88,6 +89,10 @@ void AttentionViewerROS::callback(const sensor_msgs::ImageConstPtr& _img,
 
       // draw feature
       cv::circle(img, pix, 2, color, 2);
+
+      // draw prob
+      auto scoreColor = cv::Scalar(0, 255*prob, 255*(1 - prob));
+      cv::circle(img, pix, 2, scoreColor, 1);
 
       // // draw velocity
       // constexpr double dt = 0.10;

--- a/feature_tracker/src/cvmodified.cpp
+++ b/feature_tracker/src/cvmodified.cpp
@@ -1,0 +1,235 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+// Taken from commit 54de51ef3c6f07fb80fe1bc0e81b3b2ab8306c89
+
+#include <cstdio>
+#include <vector>
+#include <iostream>
+#include <functional>
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/features2d.hpp>
+
+#include "anticipation/cvmodified.h"
+
+using namespace cv;
+
+namespace cvmodified {
+
+struct greaterThanPtr
+{
+    bool operator () (const float * a, const float * b) const
+    // Ensure a fully deterministic result of the sort
+    { return (*a > *b) ? true : (*a < *b) ? false : (a > b); }
+};
+
+// ----------------------------------------------------------------------------
+
+void goodFeaturesToTrack( InputArray _image, OutputArray _corners, OutputArray _scores,
+                              int maxCorners, double qualityLevel, double minDistance,
+                              InputArray _mask, int blockSize, int gradientSize,
+                              bool useHarrisDetector, double harrisK )
+{
+
+    CV_Assert( qualityLevel > 0 && minDistance >= 0 && maxCorners >= 0 );
+    CV_Assert( _mask.empty() || (_mask.type() == CV_8UC1 && _mask.sameSize(_image)) );
+
+    std::cout << std::endl << "** calling modified version **" << std::endl;
+
+    Mat image = _image.getMat(), eig, tmp;
+    if (image.empty())
+    {
+        _corners.release();
+        _scores.release();
+        return;
+    }
+
+    if( useHarrisDetector )
+        cornerHarris( image, eig, blockSize, gradientSize, harrisK );
+    else
+        cornerMinEigenVal( image, eig, blockSize, gradientSize );
+
+    double maxVal = 0;
+    minMaxLoc( eig, 0, &maxVal, 0, 0, _mask );
+    threshold( eig, eig, maxVal*qualityLevel, 0, THRESH_TOZERO );
+    dilate( eig, tmp, Mat());
+
+    Size imgsize = image.size();
+    std::vector<const float*> tmpCorners;
+
+    // collect list of pointers to features - put them into temporary image
+    Mat mask = _mask.getMat();
+    for( int y = 1; y < imgsize.height - 1; y++ )
+    {
+        const float* eig_data = (const float*)eig.ptr(y);
+        const float* tmp_data = (const float*)tmp.ptr(y);
+        const uchar* mask_data = mask.data ? mask.ptr(y) : 0;
+
+        for( int x = 1; x < imgsize.width - 1; x++ )
+        {
+            float val = eig_data[x];
+            if( val != 0 && val == tmp_data[x] && (!mask_data || mask_data[x]) )
+                tmpCorners.push_back(eig_data + x);
+        }
+    }
+
+    std::vector<Point2f> corners;
+    std::vector<float> scores;
+    size_t i, j, total = tmpCorners.size(), ncorners = 0;
+
+    if (total == 0)
+    {
+        _corners.release();
+        _scores.release();
+        return;
+    }
+
+    std::sort( tmpCorners.begin(), tmpCorners.end(), greaterThanPtr() );
+
+    if (minDistance >= 1)
+    {
+         // Partition the image into larger grids
+        int w = image.cols;
+        int h = image.rows;
+
+        const int cell_size = cvRound(minDistance);
+        const int grid_width = (w + cell_size - 1) / cell_size;
+        const int grid_height = (h + cell_size - 1) / cell_size;
+
+        std::vector<std::vector<Point2f> > grid(grid_width*grid_height);
+
+        minDistance *= minDistance;
+
+        for( i = 0; i < total; i++ )
+        {
+            int ofs = (int)((const uchar*)tmpCorners[i] - eig.ptr());
+            int y = (int)(ofs / eig.step);
+            int x = (int)((ofs - y*eig.step)/sizeof(float));
+
+            bool good = true;
+
+            int x_cell = x / cell_size;
+            int y_cell = y / cell_size;
+
+            int x1 = x_cell - 1;
+            int y1 = y_cell - 1;
+            int x2 = x_cell + 1;
+            int y2 = y_cell + 1;
+
+            // boundary check
+            x1 = std::max(0, x1);
+            y1 = std::max(0, y1);
+            x2 = std::min(grid_width-1, x2);
+            y2 = std::min(grid_height-1, y2);
+
+            for( int yy = y1; yy <= y2; yy++ )
+            {
+                for( int xx = x1; xx <= x2; xx++ )
+                {
+                    std::vector <Point2f> &m = grid[yy*grid_width + xx];
+
+                    if( m.size() )
+                    {
+                        for(j = 0; j < m.size(); j++)
+                        {
+                            float dx = x - m[j].x;
+                            float dy = y - m[j].y;
+
+                            if( dx*dx + dy*dy < minDistance )
+                            {
+                                good = false;
+                                goto break_out;
+                            }
+                        }
+                    }
+                }
+            }
+
+            break_out:
+
+            if (good)
+            {
+                grid[y_cell*grid_width + x_cell].push_back(Point2f((float)x, (float)y));
+
+                corners.push_back(Point2f((float)x, (float)y));
+                scores.push_back(*tmpCorners[i]);
+                ++ncorners;
+
+                if( maxCorners > 0 && (int)ncorners == maxCorners )
+                    break;
+            }
+        }
+    }
+    else
+    {
+        for( i = 0; i < total; i++ )
+        {
+            int ofs = (int)((const uchar*)tmpCorners[i] - eig.ptr());
+            int y = (int)(ofs / eig.step);
+            int x = (int)((ofs - y*eig.step)/sizeof(float));
+
+            corners.push_back(Point2f((float)x, (float)y));
+            scores.push_back(*tmpCorners[i]);
+
+            ++ncorners;
+            if( maxCorners > 0 && (int)ncorners == maxCorners )
+                break;
+        }
+    }
+
+    Mat(corners).convertTo(_corners, _corners.fixedType() ? _corners.type() : CV_32F);
+    Mat(scores).convertTo(_scores, _scores.fixedType() ? _scores.type() : CV_32F);
+}
+
+// ----------------------------------------------------------------------------
+
+void goodFeaturesToTrack( InputArray _image, OutputArray _corners, OutputArray _scores,
+                          int maxCorners, double qualityLevel, double minDistance,
+                          InputArray _mask, int blockSize,
+                          bool useHarrisDetector, double harrisK )
+{
+    cvmodified::goodFeaturesToTrack(_image, _corners, _scores, maxCorners, qualityLevel, minDistance,
+                        _mask, blockSize, 3, useHarrisDetector, harrisK );
+}
+
+} // namespace cvmodified

--- a/feature_tracker/src/feature_tracker.cpp
+++ b/feature_tracker/src/feature_tracker.cpp
@@ -59,6 +59,7 @@ void FeatureTracker::process(const cv::Mat& img, double timestamp)
     assert(features0.size() == features1_.size());
     assert(features0.size() == ids1_.size());
     assert(features0.size() == lifetimes1_.size());
+    assert(features0.size() == scores1_.size());
 
     // Only keep features that were matched in both frames
     // and that are within the border of the image
@@ -72,6 +73,7 @@ void FeatureTracker::process(const cv::Mat& img, double timestamp)
         // update feature metadata at the same time
         ids1_[j] = (ids1_[i] == 0) ? nextId_++ : ids1_[i];  // set ID if unset
         lifetimes1_[j] = lifetimes1_[i] + 1;                // inc lifetime
+        scores1_[j] = scores1_[i];
 
         j++;
       }
@@ -80,6 +82,7 @@ void FeatureTracker::process(const cv::Mat& img, double timestamp)
     features1_.resize(j);
     ids1_.resize(j);
     lifetimes1_.resize(j);
+    scores1_.resize(j);
   }
 
   //
@@ -111,17 +114,20 @@ void FeatureTracker::process(const cv::Mat& img, double timestamp)
 
     // look for more features using mask to detect in sparse regions
     std::vector<cv::Point2f> newFeatures1;
-    detectFeatures(img1, newFeatures1, numFeaturesToDetect, mask);
+    std::vector<float> newScores1;
+    detectFeatures(img1, newFeatures1, newScores1, numFeaturesToDetect, mask);
 
     // add new features for next time
     size_t newSize = features1_.size() + newFeatures1.size();
     features1_.reserve(newSize);
     ids1_.reserve(newSize);
     lifetimes1_.reserve(newSize);
-    for (const auto& feature : newFeatures1) {
-      features1_.push_back(feature);
+    scores1_.reserve(newSize);
+    for (size_t i=0; i<newFeatures1.size(); ++i) {
+      features1_.push_back(newFeatures1[i]);
       ids1_.push_back(0);
       lifetimes1_.push_back(0);
+      scores1_.push_back(newScores1[i]);
     }
   }
 
@@ -154,6 +160,7 @@ void FeatureTracker::calculateFlow(const cv::Mat& grey0, const cv::Mat& grey1,
 
 void FeatureTracker::detectFeatures(const cv::Mat& grey,
                                     std::vector<cv::Point2f>& features,
+                                    std::vector<float>& scores,
                                     int maxCorners,
                                     const cv::Mat& mask)
 {
@@ -163,7 +170,6 @@ void FeatureTracker::detectFeatures(const cv::Mat& grey,
   constexpr bool useHarrisDetector = false;
   constexpr double k = 0.04;
 
-  std::vector<float> scores;
   cvmodified::goodFeaturesToTrack(grey, features, scores, maxCorners,
                                   cornerQuality, params_.minDistance, mask,
                                   blockSize, useHarrisDetector, k);
@@ -198,14 +204,15 @@ cv::Mat FeatureTracker::enforceMinDist(std::vector<cv::Point2f>& features0)
     auto pt = features1_[i];
     auto id = ids1_[i];
     auto ell = lifetimes1_[i];
+    auto score = scores1_[i];
 
     // note that pt0 is in the place of 'nip' for typical measurements
     // and that the 'vel' field is redundant
-    sorted.push_back(std::make_tuple(id, pt, pt0, ell, pt0));
+    sorted.push_back(std::make_tuple(id, pt, score, pt0, ell, pt0));
   }
 
   auto comp = [](const auto& a, const auto& b) -> bool {
-                    return std::get<3>(a) > std::get<3>(b);
+                    return std::get<mLIFE>(a) > std::get<mLIFE>(b);
               };
   std::sort(sorted.begin(), sorted.end(), comp);
 
@@ -215,23 +222,27 @@ cv::Mat FeatureTracker::enforceMinDist(std::vector<cv::Point2f>& features0)
 
   std::vector<cv::Point2f> kept_pts, kept_pts0;
   std::vector<unsigned int> kept_ids, kept_lifetimes;
+  std::vector<double> kept_scores;
   kept_pts0.reserve(features1_.size());
   kept_pts.reserve(features1_.size());
   kept_ids.reserve(features1_.size());
   kept_lifetimes.reserve(features1_.size());
+  kept_scores.reserve(features1_.size());
 
   for (size_t i=0; i<sorted.size(); ++i) {
-    auto pt = std::get<1>(sorted[i]);
+    auto pt = std::get<mPT>(sorted[i]);
     if (mask.at<uchar>(pt) == 255) {
-      auto id = std::get<0>(sorted[i]);
-      auto pt0 = std::get<2>(sorted[i]);
-      auto ell = std::get<3>(sorted[i]);
+      auto id = std::get<mID>(sorted[i]);
+      auto score = std::get<mSCORE>(sorted[i]);
+      auto pt0 = std::get<mNIP>(sorted[i]);
+      auto ell = std::get<mLIFE>(sorted[i]);
 
       // keep good points and their metadata
       kept_pts0.push_back(pt0);
       kept_pts.push_back(pt);
       kept_ids.push_back(id);
       kept_lifetimes.push_back(ell);
+      kept_scores.push_back(score);
 
       // update mask
       cv::circle(mask, pt, params_.minDistance, cv::Scalar(0), -1);
@@ -242,6 +253,7 @@ cv::Mat FeatureTracker::enforceMinDist(std::vector<cv::Point2f>& features0)
   kept_pts.swap(features1_);
   kept_ids.swap(ids1_);
   kept_lifetimes.swap(lifetimes1_);
+  kept_scores.swap(scores1_);
 
   return mask;
 }
@@ -270,6 +282,7 @@ bool FeatureTracker::rejectWithF(std::vector<cv::Point2f>& features0)
       features1_[j] = features1_[i];
       ids1_[j] = ids1_[i];
       lifetimes1_[j] = lifetimes1_[i];
+      scores1_[j] = scores1_[i];
       j++;
     }
   }
@@ -277,6 +290,7 @@ bool FeatureTracker::rejectWithF(std::vector<cv::Point2f>& features0)
   features1_.resize(j);
   ids1_.resize(j);
   lifetimes1_.resize(j);
+  scores1_.resize(j);
 
   return true;
 }
@@ -289,17 +303,23 @@ void FeatureTracker::createMeasurements(const std::vector<cv::Point2f>& features
   assert(features0.size() == features1_.size());
   assert(features0.size() == ids1_.size());
   assert(features0.size() == lifetimes1_.size());
+  assert(features0.size() == scores1_.size());
   assert(std::find(lifetimes1_.begin(), lifetimes1_.end(), 0) == lifetimes1_.end());
 
   // allocate memory for new measurements
   std::vector<measurement_t> measurements;
   measurements.reserve(features1_.size());
 
+  // find the largest score to use as a normalizer to convert to "probability"
+  auto it = std::max_element(scores1_.begin(), scores1_.end());
+  float eta = (it != scores1_.end()) ? *it : 1.0;
+
   for (size_t i=0; i<features1_.size(); ++i) {
     auto pt0 = features0[i];
     auto pt = features1_[i];
     auto id = ids1_[i];
     auto ell = lifetimes1_[i];
+    auto prob = scores1_[i] / eta;
 
     // undistort feature to normalized image plane
     Eigen::Vector2d a(pt.x, pt.y);
@@ -316,7 +336,7 @@ void FeatureTracker::createMeasurements(const std::vector<cv::Point2f>& features
     auto vel = (nip - nip0) / dt_;
 
     // create the measurement tuple
-    measurements.push_back(std::make_tuple(id, pt, nip, ell, vel));
+    measurements.push_back(std::make_tuple(id, pt, prob, nip, ell, vel));
   }
 
   measurements.swap(measurements_);

--- a/vins_estimator/src/feature_selector.cpp
+++ b/vins_estimator/src/feature_selector.cpp
@@ -97,7 +97,7 @@ FeatureSelector::select(image_t& image,
 
   // remove new features from image and put into image_new.
   // Image will only contain features that are currently being tracked.
-  // TODO: Is this true? Does VINS-Mono use all features in `image`?
+  // TODO: Is this true? Does VINS-Mono use *all* features given to it?
   image_t image_new;
   splitOnFeatureId(lastFeatureId_, image, image_new);
 
@@ -651,7 +651,7 @@ std::vector<int> FeatureSelector::selectInformativeFeatures(image_t& subset,
       const auto& Delta_ell = Delta_ells.at(feature_id);
 
       // find probability of this feature being tracked
-      double p = 1.0; // image.at(feature_id)[0].second.coeff(??);
+      double p = image.at(feature_id)[0].second.coeff(fPROB);
 
       // calculate logdet efficiently
       double fValue = Utility::logdet(Omega + OmegaS + p*Delta_ell, true);
@@ -670,7 +670,7 @@ std::vector<int> FeatureSelector::selectInformativeFeatures(image_t& subset,
     // caused det(M) < 0). I guess there just won't be a feature this iter.
     if (lMax > -1) {
       // Accumulate combined feature information in subset
-      double p = 1.0; // image.at(lMax)[0].second.coeff(??);
+      double p = image.at(lMax)[0].second.coeff(fPROB);
       OmegaS += p*Delta_ells.at(lMax);
 
       // add feature that returns the most information to the subset
@@ -712,7 +712,7 @@ std::map<double, int, std::greater<double>> FeatureSelector::sortedlogDetUB(
     if (in_blacklist) continue;
 
     // find probability of this feature being tracked
-    double p = 1.0; // image.at(feature_id)[0].second.coeff(??);
+    double p = image.at(feature_id)[0].second.coeff(fPROB);
 
     // construct the argument to the logdetUB function
     omega_horizon_t A = M + p*Delta_ells.at(feature_id);

--- a/vins_estimator/src/utility/state_defs.h
+++ b/vins_estimator/src/utility/state_defs.h
@@ -29,7 +29,8 @@ using ablk_t = Eigen::Matrix<double, STATE_SIZE, STATE_SIZE>;
 // map<feature_id, vector<pair< camera_id, feature >>. We assume vector.size() == 0,
 // which means the feature was only seen once in a single frame because there is only
 // one camera. Also, camera_id == 0.
-using image_t = std::map<int, std::vector<std::pair<int, Eigen::Matrix<double, 7, 1>>>>;
+enum : int { fPROB=7, fSIZE = 8 };
+using image_t = std::map<int, std::vector<std::pair<int, Eigen::Matrix<double, fSIZE, 1>>>>;
 
 
 


### PR DESCRIPTION
- Modified OpenCV `cv::goodFeaturesToTrack` to return detection scores (see [opencv-gftt-scores](https://github.com/plusk01/opencv-gftt-score))
- the scores are converted to "probability of being tracked" by normalizing the scores using the max features score
- `feature_tracker` publishes probabilities in one of the `PointCloud` message channels
- the `feature_selector` uses them
- probs are removed from the `image_t` data structure before giving them to the `vins_estimator` (gross)